### PR TITLE
Fixed buff clearing and terminate

### DIFF
--- a/wurst/buff/Buff.wurst
+++ b/wurst/buff/Buff.wurst
@@ -74,7 +74,7 @@ public function unit.clearBuffs()
 	let buffs = this.getBuffs()
 	if buffs != null
 		for bff in buffs
-			bff.onEnd()
+			bff.terminate()
 		destroy buffs
 		buffMap[this.getIndex()] = null
 
@@ -136,7 +136,7 @@ public abstract class Buff
 			destroy this
 
 	ondestroy
-		if target != null and target.isAlive()
+		if target != null
 			this.target.removeAbility(this.buffData.buffId)
 			target.removeBuff(this)
 			target.removeAbility(buffData.abilId)


### PR DESCRIPTION
1. Fixed that `clearBuffs()` doesn't terminate the buff, but only triggers `onEnd()` function. Because of that after buff duration ends, it triggers `onEnd()` function again. So you get two `onEnds()` calls overall.
2. Removed condition on alive unit, because otherwise after clearing the buffs of a unit on death, if you revive a unit, its buff stays, because it was dead, when you removed a buff. Otherwise have to clear buffs of dying unit before death, then condition could stay.