### PR TITLE
Removed useless condition

### DIFF
--- a/wurst/physics/PhysicsEntity.wurst
+++ b/wurst/physics/PhysicsEntity.wurst
@@ -20,14 +20,13 @@ public module PhysicsModule
 
 	// This function should be called every ANIMATION_PERIOD tick if the Entity is active
 	function physicsUpdate(Entity e)
-		if not e.done and e.active
-			let pos = e.getPos()
-			if DYNAMIC_Z
-				terrainZ = pos.getHeightMap()
-			if pos.z > terrainZ
-				inAir(e)
-			else
-				onGround(e)
+		let pos = e.getPos()
+		if DYNAMIC_Z
+			terrainZ = pos.getHeightMap()
+		if pos.z > terrainZ
+			inAir(e)
+		else
+			onGround(e)
 
 	// When the Entity is on or near the ground
 	function onGround(Entity e)


### PR DESCRIPTION
If we are talking about using function `physicsUpdate()` in `update()` function in a class, which extend Entity, then you can't call it before `super.update()`, because it update coords and etc.
So you have to call `physicsUpdate()` after. Thus this kind of condition appeared to check of object wasn't destroyed after super call. But actually this check is useless, cuz it takes properties of object, which, if destroyed in super call, will be null.

So have to make outer checks like that anyway:
```
super.update()
if not done
     physicsUpdate(this)
```
Then it works fine. Or do you think it can be used somewhere else, not in `update()` function?